### PR TITLE
New Parameters + Rate Limiting + General Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,63 @@ One way to get your token is to obtain it here:
 
 https://api.slack.com/custom-integrations/legacy-tokens
 
-dependencies:
+## Dependencies
 ```
-   pip install slacker #https://github.com/os/slacker
+pip install slacker # https://github.com/os/slacker
 ```
 
-usage examples
+## Basic Usage
 ```
-   python slack_export.py --token=xoxs-123123-123123-4123-0a141234
-   python slack_export.py --token=123token --dryRun
-   python slack_export.py --token=123token --skipDirectMessages
-   python slack_export.py --token=123token --skipDirectMessages --skipPrivateChannels -zip slack_export_1
-   python slack_export.py --token=123token --onlySpecifiedPrivateChannels General Random --dryRun
+# Export all Channels and DMs
+python slack_export.py --token xoxs-123...
+
+# List the Channels and DMs available for export
+python slack_export.py --token xoxs-123... --dryRun
+
+# Generate a `slack_export.zip` file for use with slack-export-viewer
+python slack_export.py --token xoxs-123... --zip slack_export
+```
+
+## Selecting Conversations to Export
+
+This script exports **all** Channels and DMs by default.
+
+To export only certain conversations, use one or more of the following arguments:
+
+* `--publicChannels [CHANNEL_NAME [CHANNEL_NAME ...]]`\
+Export Public Channels\
+(optionally filtered by the given channel names)
+
+* `--groups [GROUP_NAME [GROUP_NAME ...]]`\
+Export Private Channels and Group DMs\
+(optionally filtered by the given group names)
+
+* `--directMessages [USER_NAME [USER_NAME ...]]`\
+Export 1:1 DMs\
+(optionally filtered by the given user names)
+
+### Examples
+```
+# Export only Public Channels
+python slack_export.py --token xoxs-123... --publicChannels
+
+# Export only the "General" and "Random" Public Channels
+python slack_export.py --token xoxs-123... --publicChannels General Random
+
+# Export only Private Channels and Group DMs
+python slack_export.py --token xoxs-123... --groups
+
+# Export only the "my_private_channel" Private Channel
+python slack_export.py --token xoxs-123... --groups my_private_channel
+
+# Export only 1:1 DMs
+python slack_export.py --token xoxs-123... --directMessages
+
+# Export only 1:1 DMs with jane_smith and john_doe
+python slack_export.py --token xoxs-123... --directMessages jane_smith john_doe
+
+# Export only Public/Private Channels and Group DMs (no 1:1 DMs)
+python slack_export.py --token xoxs-123... --publicChannels --groups
 ```
 This script is provided in an as-is state and I guarantee no updates or quality of service at this time.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ https://api.slack.com/custom-integrations/legacy-tokens
 ## Dependencies
 ```
 pip install slacker # https://github.com/os/slacker
+pip install pick # https://github.com/wong2/pick
 ```
 
 ## Basic Usage
@@ -30,6 +31,9 @@ python slack_export.py --token xoxs-123...
 
 # List the Channels and DMs available for export
 python slack_export.py --token xoxs-123... --dryRun
+
+# Prompt you to select the Channels and DMs to export
+python slack_export.py --token xoxs-123... --prompt
 
 # Generate a `slack_export.zip` file for use with slack-export-viewer
 python slack_export.py --token xoxs-123... --zip slack_export
@@ -53,6 +57,10 @@ Export Private Channels and Group DMs\
 Export 1:1 DMs\
 (optionally filtered by the given user names)
 
+* `--prompt`\
+Prompt you to select the conversations to export\
+(Any channel/group/user names specified with the other arguments take precedence.)
+
 ### Examples
 ```
 # Export only Public Channels
@@ -75,6 +83,9 @@ python slack_export.py --token xoxs-123... --directMessages jane_smith john_doe
 
 # Export only Public/Private Channels and Group DMs (no 1:1 DMs)
 python slack_export.py --token xoxs-123... --publicChannels --groups
+
+# Export only 1:1 DMs with jane_smith and the Public Channels you select when prompted
+python slack_export.py --token xoxs-123... --directMessages jane_smith --publicChannels --prompt
 ```
 This script is provided in an as-is state and I guarantee no updates or quality of service at this time.
 

--- a/slack_export.py
+++ b/slack_export.py
@@ -7,34 +7,6 @@ import shutil
 import copy
 from datetime import datetime
 
-# This script finds all channels, private channels and direct messages
-# that your user participates in, downloads the complete history for
-# those converations and writes each conversation out to seperate json files.
-#
-# This user centric history gathering is nice because the official slack data exporter
-# only exports public channels.
-#
-# PS, this only works if your slack team has a paid account which allows for unlimited history.
-#
-# PPS, this use of the API is blessed by Slack.
-# https://get.slack.help/hc/en-us/articles/204897248
-# " If you want to export the contents of your own private groups and direct messages
-# please see our API documentation."
-#
-# get your slack user token at the bottom of this page
-# https://api.slack.com/web
-#
-# dependencies:
-#    pip install slacker #https://github.com/os/slacker
-#
-# usage examples
-#    python slack_export.py --token=xoxs-123123-123123-4123-0a141234
-#    python slack_export.py --token=123token --dryRun
-#    python slack_export.py --token=123token --skipDirectMessages
-#    python slack_export.py --token=123token --skipDirectMessages --skipPrivateChannels -zip slack_export_1
-#    python slack_export.py --token=123token --onlySpecifiedPrivateChannels General Random --dryRun
-
-
 # fetches the complete message history for a channel/group/im
 #
 # pageableObject could be:

--- a/slack_export.py
+++ b/slack_export.py
@@ -115,13 +115,15 @@ def promptForPublicChannels(channels):
 
 # fetch and write history for all public channels
 def fetchPublicChannels(channels):
-    print("Obtaining Channel Histories: ")
     if dryRun:
+        print("Public Channels selected for export:")
         for channel in channels:
             print(channel['name'])
+        print()
         return
+
     for channel in channels:
-        print("getting history for channel {0}".format(channel['name']))
+        print("Fetching history for Public Channel: {0}".format(channel['name']))
         channelDir = channel['name']
         mkdir( channelDir )
         messages = getHistory(slack.channels, channel['id'])
@@ -166,15 +168,16 @@ def promptForDirectMessages(dms):
 # fetch and write history for all direct message conversations
 # also known as IMs in the slack API.
 def fetchDirectMessages(dms):
-    print("Found direct messages (1:1) with the following users:")
-
     if dryRun:
+        print("1:1 DMs selected for export:")
         for dm in dms:
             print(userNamesById.get(dm['user'], dm['user'] + " (name unknown)"))
+        print()
         return
+
     for dm in dms:
         name = userNamesById.get(dm['user'], dm['user'] + " (name unknown)")
-        print("getting history for direct messages with {0}".format(name))
+        print("Fetching 1:1 DMs with {0}".format(name))
         dmId = dm['id']
         mkdir(dmId)
         messages = getHistory(slack.im, dm['id'])
@@ -189,18 +192,18 @@ def promptForGroups(groups):
 # fetch and write history for specific private channel
 # also known as groups in the slack API.
 def fetchGroups(groups):
-    print("Getting history for Private Channels and Group Messages")
-
     if dryRun:
+        print("Private Channels and Group DMs selected for export:")
         for group in groups:
-            print("{0}: ({1} members)".format(group['name'], len(group['members'])))
+            print(group['name'])
+        print()
         return
 
     for group in groups:
         groupDir = group['name']
         mkdir(groupDir)
         messages = []
-        print("getting history for private channel {0} with id {1}".format(group['name'], group['id']))
+        print("Fetching history for Private Channel / Group DM: {0}".format(group['name']))
         messages = getHistory(slack.groups, group['id'])
         parseMessages( groupDir, messages, 'group' )
 
@@ -229,19 +232,19 @@ def doTestAuth():
 def bootstrapKeyValues():
     global users, channels, groups, dms
     users = slack.users.list().body['members']
-    print("found {0} users ".format(len(users)))
+    print("Found {0} Users".format(len(users)))
     sleep(1)
     
     channels = slack.channels.list().body['channels']
-    print("found {0} channels ".format(len(channels)))
+    print("Found {0} Public Channels".format(len(channels)))
     sleep(1)
 
     groups = slack.groups.list().body['groups']
-    print("found {0} private channels or group messages".format(len(groups)))
+    print("Found {0} Private Channels or Group DMs".format(len(groups)))
     sleep(1)
 
     dms = slack.im.list().body['ims']
-    print("found {0} unique user direct messages".format(len(dms)))
+    print("Found {0} 1:1 DM conversations\n".format(len(dms)))
     sleep(1)
 
     getUserMap()
@@ -281,43 +284,43 @@ def finalize():
     exit()
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='download slack history')
+    parser = argparse.ArgumentParser(description='Export Slack history')
 
-    parser.add_argument('--token', required=True, help="an api token for a slack user")
-    parser.add_argument('--zip', help="name of a zip file to output as")
+    parser.add_argument('--token', required=True, help="Slack API token")
+    parser.add_argument('--zip', help="Name of a zip file to output as")
 
     parser.add_argument(
         '--dryRun',
         action='store_true',
         default=False,
-        help="if dryRun is true, don't fetch/write history only get channel names")
+        help="List the conversations that will be exported (don't fetch/write history)")
 
     parser.add_argument(
         '--publicChannels',
         nargs='*',
         default=None,
         metavar='CHANNEL_NAME',
-        help="export the given public channels")
+        help="Export the given Public Channels")
 
     parser.add_argument(
         '--groups',
         nargs='*',
         default=None,
         metavar='GROUP_NAME',
-        help="export the given private channels and group DMs")
+        help="Export the given Private Channels / Group DMs")
 
     parser.add_argument(
         '--directMessages',
         nargs='*',
         default=None,
         metavar='USER_NAME',
-        help="export 1:1 DMs with the given users")
+        help="Export 1:1 DMs with the given users")
 
     parser.add_argument(
         '--prompt',
         action='store_true',
         default=False,
-        help="prompt you to select the conversations to export")
+        help="Prompt you to select the conversations to export")
 
     args = parser.parse_args()
 

--- a/slack_export.py
+++ b/slack_export.py
@@ -108,7 +108,7 @@ def getChannels():
     print("Obtaining Channel Histories: ")
     if dryRun:
         for channel in channels:
-            print(channel['name'].encode("utf-8"))
+            print(channel['name'])
         return
     for channel in channels:
         print("getting history for channel {0}".format(channel['name']))

--- a/slack_export.py
+++ b/slack_export.py
@@ -241,7 +241,7 @@ def finalize():
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='download slack history')
 
-    parser.add_argument('--token', help="an api token for a slack user")
+    parser.add_argument('--token', required=True, help="an api token for a slack user")
     parser.add_argument('--zip', help="name of a zip file to output as")
 
     parser.add_argument(

--- a/slack_export.py
+++ b/slack_export.py
@@ -7,6 +7,7 @@ import shutil
 import copy
 from datetime import datetime
 from pick import pick
+from time import sleep
 
 # fetches the complete message history for a channel/group/im
 #
@@ -32,6 +33,7 @@ def getHistory(pageableObject, channelId, pageSize = 100):
 
         if (response['has_more'] == True):
             lastTimestamp = messages[-1]['ts'] # -1 means last element in a list
+            sleep(1) # Respect the Slack API rate limit
         else:
             break
     return messages
@@ -228,15 +230,19 @@ def bootstrapKeyValues():
     global users, channels, groups, dms
     users = slack.users.list().body['members']
     print("found {0} users ".format(len(users)))
+    sleep(1)
     
     channels = slack.channels.list().body['channels']
     print("found {0} channels ".format(len(channels)))
+    sleep(1)
 
     groups = slack.groups.list().body['groups']
     print("found {0} private channels or group messages".format(len(groups)))
+    sleep(1)
 
     dms = slack.im.list().body['ims']
     print("found {0} unique user direct messages".format(len(dms)))
+    sleep(1)
 
     getUserMap()
 


### PR DESCRIPTION
This PR includes various changes that I was working on in [my fork](https://github.com/eromba/slack-export):

* New arguments for selecting the conversations to export:
  * `--publicChannels`
  * `--groups`
  * `--directMessages`
  * `--prompt` (makes the script prompt you to select conversations)
* `sleep()` calls to abide by the Slack API rate limits
* General Cleanup:
  * Remove the large header comment in favor of the README
  * Fix printing of Channel names during dry-run
  * Make the `--token` argument required
  * Cleanup terminal output

See the individual commits and updated README for details.