### PR TITLE
Fix DM conversations being skipped during download

### DIFF
--- a/slack_export.py
+++ b/slack_export.py
@@ -182,7 +182,6 @@ def fetchDirectMessages(dms):
         mkdir(dmId)
         messages = getHistory(slack.im, dm['id'])
         parseMessages( dmId, messages, "im" )
-        return
 
 def promptForGroups(groups):
     groupNames = [group['name'] for group in groups]


### PR DESCRIPTION
This PR removes an extra `return` statement that causes the script to skip downloading all DM conversations after the first one.