### PR TITLE
fix non-utf8 channel name handling

### DIFF
--- a/slack_export.py
+++ b/slack_export.py
@@ -123,8 +123,9 @@ def fetchPublicChannels(channels):
         return
 
     for channel in channels:
-        print("Fetching history for Public Channel: {0}".format(channel['name']))
-        channelDir = channel['name']
+        channelDir = channel['name'].encode('utf-8')
+        print("Fetching history for Public Channel: {0}".format(channelDir))
+        channelDir = channel['name'].encode('utf-8')
         mkdir( channelDir )
         messages = getHistory(slack.channels, channel['id'])
         parseMessages( channelDir, messages, 'channel')


### PR DESCRIPTION
when backing up a channel with chinese characters, got his error : 
```
Traceback (most recent call last):
  File "slack_export.py", line 369, in <module>
    fetchPublicChannels(selectedChannels)
  File "slack_export.py", line 126, in fetchPublicChannels
    print("Fetching history for Public Channel: {0}".format(channel['name']))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-1: ordinal not in range(128)
```

encoding channel name to utf8 fix it