### PR TITLE
prevent empty ".json" files from being written

### DIFF
--- a/slack_export.py
+++ b/slack_export.py
@@ -68,6 +68,10 @@ def channelRename( oldRoomName, newRoomName ):
 def writeMessageFile( fileName, messages ):
     directory = os.path.dirname(fileName)
 
+    # if there's no data to write to the file, return
+    if not messages:
+        return
+
     if not os.path.isdir( directory ):
         mkdir( directory )
 


### PR DESCRIPTION
I've been running into trouble with this bit of logic:

https://github.com/zach-snell/slack-export/blob/ec88df700925da4ca3ea62d2d96383c5d53c4b5f/slack_export.py#L82-L92

The first time through the `messages` loop,  `currentFileDate` and `currentMessages` are both uninitialized, which results in 

```
writeMessageFile( roomDIR/.json, [] )
```

This creates an empty `.json` file in each exported channel's directory. 

This isn't bad on it's own, but when a Slack message comes through specifying a change to a channel's name, this error occurs because of the empty .json file:

```
Traceback (most recent call last):
  File "slack_export.py", line 375, in <module>
    fetchGroups(selectedGroups)
  File "slack_export.py", line 208, in fetchGroups
    parseMessages( groupDir, messages, 'group' )
  File "slack_export.py", line 102, in parseMessages
    channelRename( oldRoomPath, newRoomPath )
  File "slack_export.py", line 64, in channelRename
    shutil.move( os.path.join( oldRoomName, fileName ), newRoomName )
  File "/home/tj/Programming/slackExport/ve/slack-export/lib/python3.6/shutil.py", line 542, in move
    raise Error("Destination path '%s' already exists" % real_dst)
```

This PR adds a conditional to `writeMessageFile` to check whether or not there's any data to write to disk. If there isn't, the method returns without creating a new, empty file. 

Fixes #1 