### PR TITLE
Fix export order.

### DIFF
--- a/slack_export.py
+++ b/slack_export.py
@@ -36,6 +36,9 @@ def getHistory(pageableObject, channelId, pageSize = 100):
             sleep(1) # Respect the Slack API rate limit
         else:
             break
+
+    messages.sort(key = lambda message: message['ts'])
+
     return messages
 
 


### PR DESCRIPTION
Prior to this the messages, when retrieved via multiple requests, were not in cronological order.