### PR TITLE
fix for groups with unicode characters

### DIFF
--- a/slack_export.py
+++ b/slack_export.py
@@ -88,7 +88,7 @@ def parseMessages( roomDir, messages, roomType ):
 
         #if it's on a different day, write out the previous day's messages
         if fileDate != currentFileDate:
-            outFileName = '{room}/{file}.json'.format( room = roomDir, file = currentFileDate )
+            outFileName = u'{room}/{file}.json'.format( room = roomDir, file = currentFileDate )
             writeMessageFile( outFileName, currentMessages )
             currentFileDate = fileDate
             currentMessages = []
@@ -102,7 +102,7 @@ def parseMessages( roomDir, messages, roomType ):
             channelRename( oldRoomPath, newRoomPath )
 
         currentMessages.append( message )
-    outFileName = '{room}/{file}.json'.format( room = roomDir, file = currentFileDate )
+    outFileName = u'{room}/{file}.json'.format( room = roomDir, file = currentFileDate )
     writeMessageFile( outFileName, currentMessages )
 
 def filterConversationsByName(channelsOrGroups, channelOrGroupNames):
@@ -124,7 +124,7 @@ def fetchPublicChannels(channels):
 
     for channel in channels:
         channelDir = channel['name'].encode('utf-8')
-        print("Fetching history for Public Channel: {0}".format(channelDir))
+        print(u"Fetching history for Public Channel: {0}".format(channelDir))
         channelDir = channel['name'].encode('utf-8')
         mkdir( channelDir )
         messages = getHistory(slack.channels, channel['id'])
@@ -178,7 +178,7 @@ def fetchDirectMessages(dms):
 
     for dm in dms:
         name = userNamesById.get(dm['user'], dm['user'] + " (name unknown)")
-        print("Fetching 1:1 DMs with {0}".format(name))
+        print(u"Fetching 1:1 DMs with {0}".format(name))
         dmId = dm['id']
         mkdir(dmId)
         messages = getHistory(slack.im, dm['id'])
@@ -203,7 +203,7 @@ def fetchGroups(groups):
         groupDir = group['name']
         mkdir(groupDir)
         messages = []
-        print("Fetching history for Private Channel / Group DM: {0}".format(group['name']))
+        print(u"Fetching history for Private Channel / Group DM: {0}".format(group['name']))
         messages = getHistory(slack.groups, group['id'])
         parseMessages( groupDir, messages, 'group' )
 
@@ -225,26 +225,26 @@ def doTestAuth():
     testAuth = slack.auth.test().body
     teamName = testAuth['team']
     currentUser = testAuth['user']
-    print("Successfully authenticated for team {0} and user {1} ".format(teamName, currentUser))
+    print(u"Successfully authenticated for team {0} and user {1} ".format(teamName, currentUser))
     return testAuth
 
 # Since Slacker does not Cache.. populate some reused lists
 def bootstrapKeyValues():
     global users, channels, groups, dms
     users = slack.users.list().body['members']
-    print("Found {0} Users".format(len(users)))
+    print(u"Found {0} Users".format(len(users)))
     sleep(1)
     
     channels = slack.channels.list().body['channels']
-    print("Found {0} Public Channels".format(len(channels)))
+    print(u"Found {0} Public Channels".format(len(channels)))
     sleep(1)
 
     groups = slack.groups.list().body['groups']
-    print("Found {0} Private Channels or Group DMs".format(len(groups)))
+    print(u"Found {0} Private Channels or Group DMs".format(len(groups)))
     sleep(1)
 
     dms = slack.im.list().body['ims']
-    print("Found {0} 1:1 DM conversations\n".format(len(dms)))
+    print(u"Found {0} 1:1 DM conversations\n".format(len(dms)))
     sleep(1)
 
     getUserMap()
@@ -273,7 +273,7 @@ def dumpDummyChannel():
     channelName = channels[0]['name']
     mkdir( channelName )
     fileDate = '{:%Y-%m-%d}'.format(datetime.today())
-    outFileName = '{room}/{file}.json'.format( room = channelName, file = fileDate )
+    outFileName = u'{room}/{file}.json'.format( room = channelName, file = fileDate )
     writeMessageFile(outFileName, [])
 
 def finalize():


### PR DESCRIPTION
The error was;
```
Fetching history for Private Channel / Group DM: kahvaltı
Traceback (most recent call last):
  File "slack_export.py", line 375, in <module>
    fetchGroups(selectedGroups)
  File "slack_export.py", line 208, in fetchGroups
    parseMessages( groupDir, messages, 'group' )
  File "slack_export.py", line 91, in parseMessages
    outFileName = '{room}/{file}.json'.format( room = roomDir, file = currentFileDate )
UnicodeEncodeError: 'ascii' codec can't encode character u'\u0131' in position 7: ordinal not in range(128)
```