### PR TITLE
sort message order

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,16 @@ One way to get your token is to obtain it here:
 https://api.slack.com/custom-integrations/legacy-tokens
 
 ## Dependencies
+
+Use python2 to run this project.
+
 ```
 pip install slacker # https://github.com/os/slacker
 pip install pick # https://github.com/wong2/pick
 ```
 
 ## Basic Usage
+
 ```
 # Export all Channels and DMs
 python slack_export.py --token xoxs-123...

--- a/slack_export.py
+++ b/slack_export.py
@@ -36,6 +36,9 @@ def getHistory(pageableObject, channelId, pageSize = 100):
             sleep(1) # Respect the Slack API rate limit
         else:
             break
+
+        messages.sort(key = lambda message: message['ts'])
+
     return messages
 
 
@@ -142,7 +145,7 @@ def dumpChannelFile():
             mpim.append(group)
             continue
         private.append(group)
-    
+
     # slack viewer wants DMs to have a members list, not sure why but doing as they expect
     for dm in dms:
         dm['members'] = [dm['user'], tokenOwnerId]
@@ -234,7 +237,7 @@ def bootstrapKeyValues():
     users = slack.users.list().body['members']
     print("Found {0} Users".format(len(users)))
     sleep(1)
-    
+
     channels = slack.channels.list().body['channels']
     print("Found {0} Public Channels".format(len(channels)))
     sleep(1)
@@ -324,7 +327,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    users = []    
+    users = []
     channels = []
     groups = []
     dms = []


### PR DESCRIPTION
messages weren't sorted when i tried this tool.. maybe something in the slack api changed

also, using python3 created misnamed directories which caused slack-export-viewer to fail, so I added a note to the readme about using python2