### PR TITLE
Fix rate limit exceeded error

### DIFF
--- a/slack_export.py
+++ b/slack_export.py
@@ -22,6 +22,7 @@ def getHistory(pageableObject, channelId, pageSize = 100):
     lastTimestamp = None
 
     while(True):
+        sleep(1) # Respect the Slack API rate limit
         response = pageableObject.history(
             channel = channelId,
             latest    = lastTimestamp,
@@ -33,7 +34,6 @@ def getHistory(pageableObject, channelId, pageSize = 100):
 
         if (response['has_more'] == True):
             lastTimestamp = messages[-1]['ts'] # -1 means last element in a list
-            sleep(1) # Respect the Slack API rate limit
         else:
             break
 


### PR DESCRIPTION
In getHistory we do a sleep after each 100 messages to avoid exceeding slack's API limit.

But the sleep is only done after we get the first 100 messages, so if we have multiple channels in a row with less than 100 messages then the sleep is never done and we may exceed 1 request per second.
