### PR TITLE
Fix duplicate folders in export

### DIFF
--- a/slack_export.py
+++ b/slack_export.py
@@ -130,9 +130,8 @@ def fetchPublicChannels(channels):
         return
 
     for channel in channels:
-        channelDir = channel['name'].encode('utf-8')
-        print(u"Fetching history for Public Channel: {0}".format(channelDir))
-        channelDir = channel['name'].encode('utf-8')
+        channelDir = channel['name']
+        print("Fetching history for Public Channel: {0}".format(channelDir))
         mkdir( channelDir )
         messages = getHistory(slack.channels, channel['id'])
         parseMessages( channelDir, messages, 'channel')
@@ -185,7 +184,7 @@ def fetchDirectMessages(dms):
 
     for dm in dms:
         name = userNamesById.get(dm['user'], dm['user'] + " (name unknown)")
-        print(u"Fetching 1:1 DMs with {0}".format(name))
+        print("Fetching 1:1 DMs with {0}".format(name))
         dmId = dm['id']
         mkdir(dmId)
         messages = getHistory(slack.im, dm['id'])
@@ -210,7 +209,7 @@ def fetchGroups(groups):
         groupDir = group['name']
         mkdir(groupDir)
         messages = []
-        print(u"Fetching history for Private Channel / Group DM: {0}".format(group['name']))
+        print("Fetching history for Private Channel / Group DM: {0}".format(group['name']))
         messages = getHistory(slack.groups, group['id'])
         parseMessages( groupDir, messages, 'group' )
 
@@ -232,26 +231,26 @@ def doTestAuth():
     testAuth = slack.auth.test().body
     teamName = testAuth['team']
     currentUser = testAuth['user']
-    print(u"Successfully authenticated for team {0} and user {1} ".format(teamName, currentUser))
+    print("Successfully authenticated for team {0} and user {1} ".format(teamName, currentUser))
     return testAuth
 
 # Since Slacker does not Cache.. populate some reused lists
 def bootstrapKeyValues():
     global users, channels, groups, dms
     users = slack.users.list().body['members']
-    print(u"Found {0} Users".format(len(users)))
+    print("Found {0} Users".format(len(users)))
     sleep(1)
     
     channels = slack.channels.list().body['channels']
-    print(u"Found {0} Public Channels".format(len(channels)))
+    print("Found {0} Public Channels".format(len(channels)))
     sleep(1)
 
     groups = slack.groups.list().body['groups']
-    print(u"Found {0} Private Channels or Group DMs".format(len(groups)))
+    print("Found {0} Private Channels or Group DMs".format(len(groups)))
     sleep(1)
 
     dms = slack.im.list().body['ims']
-    print(u"Found {0} 1:1 DM conversations\n".format(len(dms)))
+    print("Found {0} 1:1 DM conversations\n".format(len(dms)))
     sleep(1)
 
     getUserMap()


### PR DESCRIPTION
Pull requests #5 and #13 attempted to fix issues with non ascii characters in channel names or user names.

They don't seem to have fixed the issue properly and caused duplicate folders e.g. "general" and "b'general'.

Revert the changes for now until we find a better fix.

I tested using python3 on linux with channel names "ἐγκύκλιος-παιδεία" and "松弛的出口蛇" and had no issues.

```
Fetching history for Public Channel: 松弛的出口蛇
Fetching history for Private Channel / Group DM: ἐγκύκλιος-παιδεία
```