### PR TITLE
Slack conversations api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+
+# exports
+2020*/
+2019*/
+
+# VSCode settings file
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/slack_export.py
+++ b/slack_export.py
@@ -26,7 +26,7 @@ def getHistory(pageableObject, channelId, pageSize = 100):
             channel = channelId,
             latest    = lastTimestamp,
             oldest    = 0,
-            count     = pageSize
+            limit     = pageSize
         ).body
 
         messages.extend(response['messages'])
@@ -134,7 +134,7 @@ def fetchPublicChannels(channels):
         print(u"Fetching history for Public Channel: {0}".format(channelDir))
         channelDir = channel['name'].encode('utf-8')
         mkdir( channelDir )
-        messages = getHistory(slack.channels, channel['id'])
+        messages = getHistory(slack.conversations, channel['id'])
         parseMessages( channelDir, messages, 'channel')
 
 # write channels.json file
@@ -211,7 +211,7 @@ def fetchGroups(groups):
         mkdir(groupDir)
         messages = []
         print(u"Fetching history for Private Channel / Group DM: {0}".format(group['name']))
-        messages = getHistory(slack.groups, group['id'])
+        messages = getHistory(slack.conversations, group['id'])
         parseMessages( groupDir, messages, 'group' )
 
 # fetch all users for the channel and return a map userId -> userName
@@ -242,15 +242,19 @@ def bootstrapKeyValues():
     print(u"Found {0} Users".format(len(users)))
     sleep(1)
     
-    channels = slack.channels.list().body['channels']
+    channels = slack.conversations.list(limit = 1000, types=('public_channel')).body['channels']
     print(u"Found {0} Public Channels".format(len(channels)))
     sleep(1)
 
-    groups = slack.groups.list().body['groups']
+    groups = slack.conversations.list(limit = 1000, types=('private_channel', 'mpim')).body['channels']
     print(u"Found {0} Private Channels or Group DMs".format(len(groups)))
+    # need to retrieve channel memberships for the slack-export-viewer to work
+    for n in range(len(groups)):
+        groups[n]["members"] = slack.conversations.members(limit=1000, channel=groups[n]['id']).body['members']
+        print(u"Retrieved members of {0}".format(groups[n]['name']))
     sleep(1)
 
-    dms = slack.im.list().body['ims']
+    dms = slack.conversations.list(limit = 1000, types=('im')).body['channels']
     print(u"Found {0} 1:1 DM conversations\n".format(len(dms)))
     sleep(1)
 


### PR DESCRIPTION
This moves the code to Slack's conversations API as the previous APIs have been deprecated (and this caused me the problem described in Issue #26).

This change required some modifications on how to fetch groups to also fetch membership information (as this is no longer part of the API response for a group, and slack-export-viewer fails if there is no membership for a channel).  Ideally, the code would do this only for requested groups as it takes time.