### PR TITLE
Updated to use slack_sdk instead of slacker

### DIFF
--- a/slack_export.py
+++ b/slack_export.py
@@ -23,7 +23,7 @@ class Slacker_Wrapper:
     def __init__(self, token):
         self.client = WebClient(token=token)
         self.channels = self.Convo(self.client, "public_channel")
-        self.groups = self.Convo(self.client, "private_channel, mpim")
+        self.groups = self.Convo(self.client, "private_channel,mpim")
         self.im = self.Convo(self.client, "im")
         self.auth = self.Auth(self.client)
         self.users = self.Users(self.client)

--- a/slack_export.py
+++ b/slack_export.py
@@ -23,7 +23,7 @@ class Slacker_Wrapper:
     def __init__(self, token):
         self.client = WebClient(token=token)
         self.channels = self.Convo(self.client, "public_channel")
-        self.groups = self.Convo(self.client, "private_channel")
+        self.groups = self.Convo(self.client, "private_channel, mpim")
         self.im = self.Convo(self.client, "im")
         self.auth = self.Auth(self.client)
         self.users = self.Users(self.client)


### PR DESCRIPTION
Updated the code to use the [slack_sdk](https://github.com/slackapi/python-slack-sdk), which is officially supported by Slack. Legacy API tokens also do not work any longer, so the user needs to create a slack app in their workspace and provide appropriate permissions scope for reading and getting the history of channels, groups and ims, as well as reading the list of users. Once the user obtains a user token from this custom app (of form "xoxp-..."), they can use it in place of a legacy token.